### PR TITLE
Removes unnecessary ternary operater

### DIFF
--- a/lib/object_perform_later.rb
+++ b/lib/object_perform_later.rb
@@ -29,7 +29,7 @@ module ObjectKiqit
     end
 
     def perform_now(method, args)
-      args.size == 1 ? send(method, args.first) : send(method, *args)
+      send(method, *args)
     end
 end
 


### PR DESCRIPTION
We shouldn't have to check the length of args in the perform method.  Since we are sending the `*args` to `send`.

Single parameter
`perform_now(method, 'something') => send(method, 'something')`

no parameters
`perform_now(method) = send(method)`

Multiple parameters
`perform_now(method, [1,2,3]) => send(method, 1, 2, 3)`
